### PR TITLE
Release 2.1.0 - Add wishlist event hooks

### DIFF
--- a/tasks/copy.js
+++ b/tasks/copy.js
@@ -8,6 +8,7 @@ const liquidPaths = [
   '*snippets/**/*',
   '*sections/**/*',
   '*templates/**/*',
+  '*layout/**/*',
 ];
 
 function renameHiddenFiles (path) {


### PR DESCRIPTION
Events:

- Document event: `shopify-wishlist:updated`
  - Triggered once a wishlist update action(add/remove) is finished
  - Usage:
    ```
    document.addEventListener('shopify-wishlist:updated', function (event) {
      var wishlist = event.detail.wishlist;
      // Your code goes here
    }
    ```

- Document event: `shopify-wishlist:init-product-grid`
  - Triggered once the product card HTML content is finished loading & appending to the document
  - Usage:
     ```
    document.addEventListener('shopify-wishlist:init-product-grid', function (event) {
       var wishlist = event.detail.wishlist;
       // Your code goes here
    }
    ```

- Document event: `shopify-wishlist:init-buttons`
  - Triggered once the wishlist button toggles have been updated to proper active/inactive state based on wishlist content
  - Usage:
     ```
    document.addEventListener('shopify-wishlist:init-buttons', function (event) {
       var wishlist = event.detail.wishlist;
       // Your code goes here
    }
    ```
